### PR TITLE
Bugfix/escape invalid character

### DIFF
--- a/lib/egzact/utils.egi
+++ b/lib/egzact/utils.egi
@@ -136,6 +136,18 @@
     (join-string row-sep
                  (map (join-string field-sep $) cols))))
 
+; Escape particular character
+; Example: escaping "a" character.
+; > ((escape-chars c#a) {c#a c#b c#c c#a c#b c#d})
+; {c#\ c#a c#b c#c c#\ c#a c#b c#d}
+(define $escape-chars
+  (lambda [$target]
+    (match-lambda (list char)
+      {[<nil> {}]
+       [<cons (& $c ,target) $cs>  (append {c#\ c} ((escape-chars target) cs))]
+       [<cons $c $cs>  (append {c} ((escape-chars target) cs))]
+       })))
+
 ; (proc "," {"a" "b" "c"}); => "a,b,c"
 (define $join-string
   (lambda [$fs $ls]

--- a/lib/egzact/utils.egi
+++ b/lib/egzact/utils.egi
@@ -126,7 +126,7 @@
         { "(match-lambda something {"
         (S.concat
           (map 2#(S.concat {"[," %1 " " %2 "] "})
-               (map 3#[(show %1) (show %3)]
+               (map 3#[(show (escape-string %1)) (show (escape-string %3))]
                     (map 1#(car (regex "=" %1)) args))))
         " [_ []]})"}))))
 
@@ -153,6 +153,7 @@
 ; Example:
 ; > (escape-string "\"hoge\"fuga")
 ; "\"hoge\"fuga"
+; ; (Not ""hoge"fuga")
 (define $escape-string
   (lambda [$target]
     (pack ((escape-chars (car (unpack ESCAPE-TARGET))) (unpack target)))))

--- a/lib/egzact/utils.egi
+++ b/lib/egzact/utils.egi
@@ -1,5 +1,5 @@
 (define $ARGMAX 65535)
-(define $ESCAPE-TARGET "\"")
+(define $ESCAPE-TARGET "\\\"")
 
 (define $S.nats?
   (lambda [$str] (not (empty? (regex "^[1-9][0-9]*$" str)))))
@@ -156,7 +156,7 @@
 ; ; (Not ""hoge"fuga")
 (define $escape-string
   (lambda [$target]
-    (pack ((escape-chars (car (unpack ESCAPE-TARGET))) (unpack target)))))
+    (pack (foldl 2#((escape-chars %2) %1) (unpack target) (unpack ESCAPE-TARGET)))))
 
 ; (proc "," {"a" "b" "c"}); => "a,b,c"
 (define $join-string

--- a/lib/egzact/utils.egi
+++ b/lib/egzact/utils.egi
@@ -1,4 +1,5 @@
 (define $ARGMAX 65535)
+(define $ESCAPE-TARGET "\"")
 
 (define $S.nats?
   (lambda [$str] (not (empty? (regex "^[1-9][0-9]*$" str)))))
@@ -147,6 +148,14 @@
        [<cons (& $c ,target) $cs>  (append {c#\ c} ((escape-chars target) cs))]
        [<cons $c $cs>  (append {c} ((escape-chars target) cs))]
        })))
+
+; Escape doubole quotation.
+; Example:
+; > (escape-string "\"hoge\"fuga")
+; "\"hoge\"fuga"
+(define $escape-string
+  (lambda [$target]
+    (pack ((escape-chars (car (unpack ESCAPE-TARGET))) (unpack target)))))
 
 ; (proc "," {"a" "b" "c"}); => "a,b,c"
 (define $join-string

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,7 @@
 #!/usr/bin/env bash
+
+# Unit testing
 runhaskell test/UnitTest.hs
+
+# Integration testing
+sh test/ShTest.sh

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+THIS_DIR=$(cd $(dirname $0) && pwd)
+
+echo $THIS_DIR
 # Unit testing
-runhaskell test/UnitTest.hs
+(cd "$THIS_DIR"; runhaskell "$THIS_DIR/test/UnitTest.hs")
 
 # Integration testing
-sh test/ShTest.sh
+sh "$THIS_DIR/test/ShTest.sh"

--- a/test/ShTest.sh
+++ b/test/ShTest.sh
@@ -108,6 +108,22 @@ AD BA BB
 BA BB BC
 BB BC BD" "${result}"
 
+	result=`echo "AA AB AC AD\nBA BB BC BD" | ./conv.egi ofs='"' 3`
+	assertEquals 'AA"AB"AC
+AB"AC"AD
+AC"AD"BA
+AD"BA"BB
+BA"BB"BC
+BB"BC"BD' "${result}"
+
+	result=`echo 'AA"AB"AC"AD"BA"BB"BC"BD' | ./conv.egi ifs="\"" ofs="\"\"" 3`
+	assertEquals 'AA""AB""AC
+AB""AC""AD
+AC""AD""BA
+AD""BA""BB
+BA""BB""BC
+BB""BC""BD' "${result}"
+
 	result=`echo "AA AB AC AD\nBA BB BC BD" | ./conv.egi each 3`
 	assertEquals "AA AB AC
 AB AC AD

--- a/test/ShTest.sh
+++ b/test/ShTest.sh
@@ -156,6 +156,13 @@ test_flat() {
 7 8
 9 10" "${result}"
 
+	result=`seq 10 | ./flat.egi ofs='"\' 2`
+	assertEquals '1"\2
+3"\4
+5"\6
+7"\8
+9"\10' "${result}"
+
 	result=`echo "AA AB AC AD\nBA BB BC BD" | ./flat.egi 3`
 	assertEquals "AA AB AC
 AD BA BB
@@ -173,6 +180,13 @@ AD
 @@@
 BA BB BC
 BD" "${result}"
+
+	result=`echo "AA AB AC AD\nBA BB BC BD" | ./flat.egi each eos='\' 3`
+	assertEquals 'AA AB AC
+AD
+\
+BA BB BC
+BD' "${result}"
 }
 
 test_slit() {

--- a/test/UnitTest.hs
+++ b/test/UnitTest.hs
@@ -31,7 +31,7 @@ runTestCase file = TestLabel file . TestCase $ do
         assertEgisonM m = fromEgisonM m >>= assertString . either show (const "")
     
         collectDefsAndTests (Define name expr) (bindings, tests) =
-          ((name, expr) : bindings, tests)
+          ((show name, expr) : bindings, tests)
         collectDefsAndTests (Test expr) (bindings, tests) =
           (bindings, expr : tests)
         collectDefsAndTests _ r = r

--- a/test/lib/utils.egi
+++ b/test/lib/utils.egi
@@ -116,10 +116,17 @@
   (twocol2string "-" "@" {})
   "")
 
+(assert-equal "escape-chars"
+  ((escape-chars c#a) {c#a c#b c#c c#a c#b c#d})
+  {c#\ c#a c#b c#c c#\ c#a c#b c#d})
+
+(assert-equal "escape-string"
+  (escape-string "\"hoge\"fuga")
+  "\\\"hoge\\\"fuga")
+
 (assert-equal "set-default-opts -- case 1"
   (set-default-opts (match-lambda something {[,"eof" "AAA"] [,"ifs" "BBB"] [,"eos" "---"] [_ {}]}))
   ["BBB" " " "\n" "\n---\n" "AAA"])
-
 (assert-equal "set-default-opts -- case 2"
   (set-default-opts (match-lambda something {[,"dummy" "1"] [_ {}]}))
   [" " " " "\n" "\n" "\n"])

--- a/test/lib/utils.egi
+++ b/test/lib/utils.egi
@@ -92,9 +92,13 @@
   (split-each-line "" {"ab bc" "12 3"})
   {{"a" "b" " " "b" "c"} {"1" "2" " " "3"}})
 
-(assert-equal "opts2hash"
-  (opts2hash {"P1=A" "P2=B"})
-  {| ["P1" "A"] ["P2" "B"] |})
+(assert-equal "opts2hash -- case 1"
+  ((opts2hash {"P1=A" "P2=B"}) "P1")
+  "A")
+
+(assert-equal "opts2hash -- case 2"
+  ((opts2hash {"P1=A" "P2="}) "P2")
+  "")
 
 (assert-equal "twocol2string -- case 1"
   (twocol2string "-" "@" {{"a" "b" "c"} {"d" "e" "f"} {"g"}})
@@ -113,11 +117,11 @@
   "")
 
 (assert-equal "set-default-opts -- case 1"
-  (set-default-opts {| ["eof" "AAA"] ["ifs" "BBB"] ["eos" "---"] |})
+  (set-default-opts (match-lambda something {[,"eof" "AAA"] [,"ifs" "BBB"] [,"eos" "---"] [_ {}]}))
   ["BBB" " " "\n" "\n---\n" "AAA"])
 
 (assert-equal "set-default-opts -- case 2"
-  (set-default-opts {| ["dummy" "1"] |})
+  (set-default-opts (match-lambda something {[,"dummy" "1"] [_ {}]}))
   [" " " " "\n" "\n" "\n"])
 
 (assert-equal "set-default-value -- case 1"


### PR DESCRIPTION
bug fix.

egzact supports double quotation `"` and backslash `\` as any separators (for `fs`, `ofs`, `ifs`, `eor`, `eos`).

```sh
$ seq 10 | flat ofs='\\"' 3
1\\"2\\"3
4\\"5\\"6
7\\"8\\"9
10
```